### PR TITLE
chore(gitignore): add .DS_Store files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ application.properties
 
 ### VS Code ###
 .vscode/
+
+### mac ###
+.DS_Store


### PR DESCRIPTION
gitignore에 .DS_Store 추가
- 맥 디렉터리 관리 파일이라서 추가하는 게 좋음